### PR TITLE
支援 GPT-5 模型

### DIFF
--- a/services/openai.js
+++ b/services/openai.js
@@ -53,14 +53,21 @@ const createChatCompletion = ({
   frequencyPenalty = config.OPENAI_COMPLETION_FREQUENCY_PENALTY,
   presencePenalty = config.OPENAI_COMPLETION_PRESENCE_PENALTY,
 }) => {
-  const body = {
-    model: hasImage({ messages }) ? config.OPENAI_VISION_MODEL : model,
+  const resolvedModel = hasImage({ messages }) ? config.OPENAI_VISION_MODEL : model;
+  let body = {
+    model: resolvedModel,
     messages,
     temperature,
-    max_tokens: maxTokens,
-    frequency_penalty: frequencyPenalty,
-    presence_penalty: presencePenalty,
+    max_completion_tokens: maxTokens,
   };
+  // Only apply penalties for non-GPT-5 models (GPT-5 handles them differently)
+  if (!/^gpt-5/.test(resolvedModel)) {
+    body = {
+      ...body,
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty,
+    };
+  }
   return client.post('/v1/chat/completions', body);
 };
 


### PR DESCRIPTION
- `max_tokens` 已棄用，改使用 `max_completion_tokens`（初步試過 `gpt-3.5-turbo`、`gpt-4.1-mini` 均能使用此屬性）
- `gpt-5` 系列
   - 不支援 `frequency_penalty`、`presence_penalty` 屬性
   - `temperature` 必須為 `1`（換句話說，如果之前有使用 `OPENAI_COMPLETION_TEMPERATURE` 環境變數的要注意一下）

> PS. 是有想過 o 系列模型要不要支援，但如果只是純聊天情境，或許可能就不太需要。 